### PR TITLE
拆分组件，优化性能，添加说明

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ dist/
 deploy_versions/
 .temp/
 .rn_temp/
+.idea
 node_modules/
 .DS_Store
 **/*.js

--- a/README.md
+++ b/README.md
@@ -251,6 +251,54 @@ export default Index;
 
 ![结构图](src/preview/样式结构.png)
 
+
+#### <font color="red">重点:</font>
+
+给`customStyleGenerator`赋值的时候不要使用临时对象，否则性能会很差
+
+<font color="red">错误用法:</font>
+```
+<Calendar
+    ...
+    customStyleGenerator={
+        params => {
+            return {
+                containerStyle: {
+
+                }
+            };
+        }
+    }
+/>
+```
+
+<font color="red">正确用法:</font>
+```
+在引用Calendar的组件的外部创建const对象，然后赋值：
+
+const customStyleGenerator = params => {
+                     return {
+                         containerStyle: {
+         
+                         }
+                     };
+                 };
+export default class XXXX extends Component {
+    render () {
+        return (
+            ...
+            <Calendar
+                ...
+                customStyleGenerator={customStyleGenerator}
+            />
+        );
+    }
+}
+```
+
+
+
+
 ## 类型说明
 
 > ### StyleGeneratorParams

--- a/src/pages/calendar/day/index.tsx
+++ b/src/pages/calendar/day/index.tsx
@@ -1,0 +1,261 @@
+import React, {FC, useEffect, useState} from 'react';
+import {View} from '@tarojs/components';
+import {
+  CalendarDateInfo,
+  CustomStyles,
+  StyleGeneratorParams
+} from "../days/index";
+import {CalendarTools, formatDate, LunarInfo} from "../utils";
+
+interface IProps {
+  onDayLongPress?: ({value}: {value: string})=>void;
+  /**
+   * 是否被选中
+   */
+  selected: boolean;
+  /** 点击事件回调 */
+  onClick: (info: CalendarDateInfo) => any;
+  value: CalendarDateInfo;
+  /** 显示模式 普通/农历 */
+  mode: 'normal' | 'lunar';
+  /** 是否范围选择模式并且endDateStr不为空 **/
+  isMultiSelectAndFinish: boolean;
+  /**
+   * 当前日期是否有mark，没有为-1
+   */
+  markIndex: number;
+  /**
+   * 当前日期是否有extraInfo，没有为-1
+   */
+  extraInfoIndex: number;
+  /** 是否显示分割线 */
+  showDivider: boolean;
+  /** 最小的可选时间 */
+  minDate: string;
+  /** 最大的可选时间 */
+  maxDate?: string | undefined;
+  /** 自定义样式生成器 */
+  customStyleGenerator?: (dateInfo: StyleGeneratorParams) => CustomStyles;
+  /** 选定时的背景色 */
+  selectedDateColor?: string;
+  /**
+   * mark的背景色
+   */
+  markColor: string|undefined;
+  markSize: string|undefined;
+  /**
+   * extraInfo的color
+   */
+  extraInfoColor: string|undefined;
+  /**
+   * extraInfo的fontSize
+   */
+  extraInfoSize: string|undefined;
+  /**
+   * extraInfo的文本
+   */
+  extraInfoText: string|undefined;
+  /**
+   * 被选择（范围选择）
+   */
+  isInRange: boolean;
+  /**
+   * 范围起点
+   */
+  rangeStart: boolean;
+  /**
+   * 范围终点
+   */
+  rangeEnd: boolean;
+  /** 禁用(不在minDate和maxDate的时间范围内的日期) */
+  disable: boolean;
+}
+
+const Day:FC<IProps> = (args)=>{
+  const {selected, onDayLongPress, onClick, value, mode, markIndex,
+    extraInfoIndex, customStyleGenerator, disable,
+    isInRange, rangeStart, rangeEnd, isMultiSelectAndFinish,
+    selectedDateColor, markColor, markSize, extraInfoColor, extraInfoSize,
+    extraInfoText,
+    showDivider} = args;
+  const [className, setClassName] = useState<Set<string>>(new Set());
+  const [customStyles, setCustomStyles] = useState<CustomStyles>({});
+
+  useEffect(()=>{
+    let set = new Set<string>();
+    const today = formatDate(new Date(), 'day');
+
+    if (!value.currentMonth || disable) {
+      // 非本月
+      set.add('not-this-month');
+    }
+    if (
+      selected &&
+      !isMultiSelectAndFinish
+    ) {
+      // 选中
+      // 范围选择模式显示已选范围时，不显示selected
+      set.add('calendar-selected');
+    }
+    if (markIndex !== -1) {
+      // 标记
+      set.add('calendar-marked');
+    }
+    if (extraInfoIndex !== -1) {
+      // 额外信息
+      set.add('calendar-extra-info');
+    }
+    if (value.fullDateStr === today) {
+      // 当天
+      set.add('calendar-today');
+    }
+    if (showDivider) {
+      // 分割线
+      set.add('calendar-line-divider');
+    }
+
+    if(isInRange) {
+      set.add('calendar-range');
+    }
+
+    if(rangeStart) {
+      set.add('calendar-range-start');
+    }
+
+    if(rangeEnd) {
+      set.add('calendar-range-end');
+    }
+
+    setClassName(set);
+  }, [disable, extraInfoIndex, isMultiSelectAndFinish, markIndex, selected,
+    showDivider, value.currentMonth, value.fullDateStr, isInRange, rangeStart, rangeEnd]);
+
+  useEffect(()=>{
+    let lunarDayInfo =
+      mode === 'lunar'
+        ? CalendarTools.solar2lunar(value.fullDateStr)
+        : null;
+    if (customStyleGenerator) {
+      // 用户定制样式
+      const generatorParams: StyleGeneratorParams = {
+        ...value,
+        lunar: lunarDayInfo,
+        selected: selected,
+        multiSelect: {
+          multiSelected: isInRange,
+          multiSelectedStar: rangeStart,
+          multiSelectedEnd: rangeEnd
+        },
+        marked: markIndex !== -1,
+        hasExtraInfo: extraInfoIndex !== -1
+      };
+      setCustomStyles(customStyleGenerator(generatorParams))
+    }
+  }, [selected, value, markIndex, extraInfoIndex, customStyleGenerator, isInRange, rangeStart, rangeEnd, mode]);
+
+
+  let lunarDayInfo =
+    mode === 'lunar'
+      ? CalendarTools.solar2lunar(value.fullDateStr)
+      : null;
+  let lunarClassName = ['lunar-day'];
+  if (lunarDayInfo) {
+    if (lunarDayInfo.IDayCn === '初一') {
+      lunarClassName.push('lunar-month');
+    }
+  }
+  return (
+    <View
+      onLongPress={
+        onDayLongPress
+          ? () => onDayLongPress({ value: value.fullDateStr })
+          : undefined
+      }
+      className={Array.from(className).join(' ')}
+      onClick={() => {
+        if (!disable) {
+          onClick(value);
+        }
+      }}
+      style={customStyles.containerStyle}
+    >
+      <View
+
+        className="calendar-date"
+        style={
+          customStyles.dateStyle || customStyles.dateStyle === {}
+            ? customStyles.dateStyle
+            : {
+              backgroundColor:
+                selected || isInRange
+                  ? selectedDateColor
+                  : ''
+            }
+        }
+      >
+        {/* 日期 */}
+        {value.date}
+      </View>
+      {mode === 'normal' ? (
+        ''
+      ) : (
+        <View
+          className={lunarClassName.join(' ')}
+          style={customStyles.lunarStyle}
+        >
+          {/* 农历 */}
+          {(() => {
+            if (!lunarDayInfo) {
+              return;
+            }
+            lunarDayInfo = lunarDayInfo as LunarInfo;
+            let dateStr: string;
+            if (lunarDayInfo.IDayCn === '初一') {
+              dateStr = lunarDayInfo.IMonthCn;
+            } else {
+              //@ts-ignore
+              dateStr = lunarDayInfo.isTerm
+                ? lunarDayInfo.Term
+                : lunarDayInfo.IDayCn;
+            }
+            return dateStr;
+          })()}
+        </View>
+      )}
+      {/* 标记 */}
+      <View
+        className="calendar-mark"
+        style={{
+          backgroundColor: markIndex === -1 ? '' : markColor,
+          height: markIndex === -1 ? '' : markSize,
+          width: markIndex === -1 ? '' : markSize,
+          top: mode === 'lunar' ? '2.0rem' : '1.5rem',
+          ...customStyles.markStyle
+        }}
+      />
+      {extraInfoIndex === -1 ? (
+        ''
+      ) : (
+        <View
+          className="calendar-extra-info"
+          style={{
+            color:
+              extraInfoIndex === -1
+                ? ''
+                : extraInfoColor,
+            fontSize:
+              extraInfoIndex === -1
+                ? ''
+                : extraInfoSize,
+            ...customStyles.extraInfoStyle
+          }}
+        >
+          {/* 额外信息 */}
+          {extraInfoText}
+        </View>
+      )}
+    </View>
+  );
+}
+
+export default React.memo(Day);

--- a/src/pages/calendar/days/index.tsx
+++ b/src/pages/calendar/days/index.tsx
@@ -1,8 +1,9 @@
 import { View } from '@tarojs/components';
 import './index.less';
-import React, { CSSProperties,FunctionComponent} from 'react';
-import { formatDate, indexOf, CalendarTools, LunarInfo } from '../utils';
+import React, {CSSProperties, FunctionComponent, useCallback, useEffect, useRef, useState} from 'react';
+import { formatDate, indexOf, LunarInfo } from '../utils';
 import { CalendarMark, ExtraInfo } from '../index';
+import Day from '../day';
 
 export type CalendarDateInfo = {
   /** 当前月的第几天1 ~ 31 */
@@ -216,65 +217,55 @@ const Days: FunctionComponent<DaysProps> = ({
   startDay,
   extraInfo
 }) => {
-  // @ts-ignore
-  const dateObj = date ? new Date(date) : new Date();
-  const minDateObj = new Date(minDate);
+  const [days, setDays] = useState<Array<CalendarDateInfo>>([]);
+  const prevDateRef = useRef<Date>(null);
+  const _onDayClick = useCallback((value)=>{
+    onClick&&onClick(value);
+  }, [onClick]);
+
+  const _onDayLongPress = useCallback(args => {
+    onDayLongPress&&onDayLongPress(args);
+  }, [onDayLongPress]);
+
+  useEffect(()=>{
+    //view和startDay基本不会变，就date会经常变化
+    //由于传递的是date对象，需要判断date对象的值是否变化，防止因为days变化导致的重复刷新
+    if(!prevDateRef.current || formatDate(prevDateRef.current) !==  formatDate(date)) {
+      // @ts-ignore
+      const dateObj = date ? new Date(date) : new Date();
+      let tempDays: CalendarDateInfo[] = [];
+      if (view === 'month') {
+        tempDays = getDateListByMonth(dateObj, startDay);
+      }
+      if (view === 'week') {
+        tempDays = getDateListByWeek(dateObj, startDay);
+      }
+      setDays(tempDays);
+    }
+    //@ts-ignore
+    prevDateRef.current = date;
+  }, [view, date, startDay ]);
+
+
   // @ts-ignore
   const maxDateObj = new Date(maxDate ? maxDate : new Date());
-  let days: CalendarDateInfo[] = [];
-  if (view === 'month') {
-    days = getDateListByMonth(dateObj, startDay);
-  }
-  if (view === 'week') {
-    days = getDateListByWeek(dateObj, startDay);
-  }
-  const today = formatDate(new Date(), 'day');
   const markDateList = marks ? marks.map(value => value.value) : [];
   const extraInfoDateList = extraInfo
     ? extraInfo.map(value => value.value)
     : [];
+  let endDateStr =  selectedRange ? selectedRange.end : '';
   const startDateObj = new Date(selectedRange ? selectedRange.start : '');
-  const endDateObj = new Date(selectedRange ? selectedRange.end : '');
+  const endDateObj = new Date(endDateStr);
+  const minDateObj = new Date(minDate);
   return (
-    <View className="calendar-body" style={bodyStyle} key = {Math.random()}>
+    <View className="calendar-body" style={bodyStyle}>
       {days.map(value => {
         const markIndex = indexOf(markDateList, value.fullDateStr);
         const extraInfoIndex = indexOf(extraInfoDateList, value.fullDateStr);
-        let disable = false;
-        let className: string[] = [];
-
-        if (!value.currentMonth) {
-          // 非本月
-          className.push('not-this-month');
-        }
-        if (
-          selectedDate === value.fullDateStr &&
-          !(isMultiSelect && selectedRange.end)
-        ) {
-          // 选中
-          // 范围选择模式显示已选范围时，不显示selected
-          className.push('calendar-selected');
-        }
-        if (markIndex !== -1) {
-          // 标记
-          className.push('calendar-marked');
-        }
-        if (extraInfoIndex !== -1) {
-          // 额外信息
-          className.push('calendar-extra-info');
-        }
-        if (value.fullDateStr === today) {
-          // 当天
-          className.push('calendar-today');
-        }
-        if (showDivider) {
-          // 分割线
-          className.push('calendar-line-divider');
-        }
         let isInRange = false;
         let rangeStart = false;
         let rangeEnd = false;
-        if (isMultiSelect && selectedRange.end) {
+        if (isMultiSelect && endDateStr) {
           // 范围选择模式
           const valueDateTimestamp = new Date(value.fullDateStr).getTime();
           if (
@@ -282,151 +273,49 @@ const Days: FunctionComponent<DaysProps> = ({
             valueDateTimestamp <= endDateObj.getTime()
           ) {
             // 被选择（范围选择）
-            className.push('calendar-range');
             isInRange = true;
             if (valueDateTimestamp === startDateObj.getTime()) {
               // 范围起点
               rangeStart = true;
-              className.push('calendar-range-start');
             }
             if (valueDateTimestamp === endDateObj.getTime()) {
               // 范围终点
               rangeEnd = true;
-              className.push('calendar-range-end');
             }
           }
         }
-        if (
-          new Date(value.fullDateStr).getTime() < minDateObj.getTime() ||
+        let disable = new Date(value.fullDateStr).getTime() < minDateObj.getTime() ||
           (maxDate &&
-            new Date(value.fullDateStr).getTime() > maxDateObj.getTime())
-        ) {
-          className.push('not-this-month');
-          disable = true;
-        }
-        let lunarDayInfo =
-          mode === 'lunar'
-            ? CalendarTools.solar2lunar(value.fullDateStr)
-            : null;
-        let lunarClassName = ['lunar-day'];
-        if (lunarDayInfo) {
-          if (lunarDayInfo.IDayCn === '初一') {
-            lunarClassName.push('lunar-month');
-          }
-        }
-        let customStyles: CustomStyles = {};
-        if (customStyleGenerator) {
-          // 用户定制样式
-          const generatorParams: StyleGeneratorParams = {
-            ...value,
-            lunar: lunarDayInfo,
-            selected: selectedDate === value.fullDateStr,
-            multiSelect: {
-              multiSelected: isInRange,
-              multiSelectedStar: rangeStart,
-              multiSelectedEnd: rangeEnd
-            },
-            marked: markIndex !== -1,
-            hasExtraInfo: extraInfoIndex !== -1
-          };
-          customStyles = customStyleGenerator(generatorParams);
-        }
+            new Date(value.fullDateStr).getTime() > maxDateObj.getTime() || false);
         return (
-          <View
-            key = {Math.random()}
-            onLongPress={
-              onDayLongPress
-                ? () => onDayLongPress({ value: value.fullDateStr })
-                : undefined
-            }
-            className={className.join(' ')}
-            onClick={() => {
-              if (!disable) {
-                onClick(value);
-              }
-            }}
-            style={customStyles.containerStyle}
-          >
-            <View
-              
-              className="calendar-date"
-              style={
-                customStyles.dateStyle || customStyles.dateStyle === {}
-                  ? customStyles.dateStyle
-                  : {
-                      backgroundColor:
-                        selectedDate === value.fullDateStr || isInRange
-                          ? selectedDateColor
-                          : ''
-                    }
-              }
-            >
-              {/* 日期 */}
-              {value.date}
-            </View>
-            {mode === 'normal' ? (
-              ''
-            ) : (
-              <View
-                className={lunarClassName.join(' ')}
-                style={customStyles.lunarStyle}
-              >
-                {/* 农历 */}
-                {(() => {
-                  if (!lunarDayInfo) {
-                    return;
-                  }
-                  lunarDayInfo = lunarDayInfo as LunarInfo;
-                  let dateStr: string;
-                  if (lunarDayInfo.IDayCn === '初一') {
-                    dateStr = lunarDayInfo.IMonthCn;
-                  } else {
-                    //@ts-ignore
-                    dateStr = lunarDayInfo.isTerm
-                      ? lunarDayInfo.Term
-                      : lunarDayInfo.IDayCn;
-                  }
-                  return dateStr;
-                })()}
-              </View>
-            )}
-            {/* 标记 */}
-            <View
-              className="calendar-mark"
-              style={{
-                backgroundColor: markIndex === -1 ? '' : marks[markIndex].color,
-                height: markIndex === -1 ? '' : marks[markIndex].markSize,
-                width: markIndex === -1 ? '' : marks[markIndex].markSize,
-                top: mode === 'lunar' ? '2.0rem' : '1.5rem',
-                ...customStyles.markStyle
-              }}
-            />
-            {extraInfoIndex === -1 ? (
-              ''
-            ) : (
-              <View
-                className="calendar-extra-info"
-                style={{
-                  color:
-                    extraInfoIndex === -1
-                      ? ''
-                      : extraInfo[extraInfoIndex].color,
-                  fontSize:
-                    extraInfoIndex === -1
-                      ? ''
-                      : extraInfo[extraInfoIndex].fontSize,
-                  ...customStyles.extraInfoStyle
-                }}
-              >
-                {/* 额外信息 */}
-                {extraInfo[extraInfoIndex].text}
-              </View>
-            )}
-          </View>
+          <Day
+            key={value.fullDateStr}
+            onDayLongPress={_onDayLongPress}
+            selected={selectedDate === value.fullDateStr}
+            isMultiSelectAndFinish={isMultiSelect && (selectedRange.end || '') != ''}
+            markIndex={markIndex}
+            extraInfoIndex={extraInfoIndex}
+            mode={mode}
+            showDivider={showDivider}
+            minDate={minDate}
+            value={value}
+            onClick={_onDayClick}
+            selectedDateColor={selectedDateColor}
+            markColor={markIndex === -1 ? '' : marks[markIndex].color}
+            markSize={markIndex === -1 ? '' : marks[markIndex].markSize}
+            extraInfoColor={extraInfoIndex === -1 ? "" : extraInfo[extraInfoIndex].color}
+            extraInfoSize={extraInfoIndex === -1 ? "" : extraInfo[extraInfoIndex].fontSize}
+            extraInfoText={extraInfoIndex === -1 ? "" : extraInfo[extraInfoIndex].text}
+            customStyleGenerator={customStyleGenerator}
+            isInRange={isInRange}
+            rangeStart={rangeStart}
+            rangeEnd={rangeEnd}
+            disable={disable}
+          />
         );
       })}
     </View>
   );
 };
 
-export default Days;
+export default React.memo(Days);


### PR DESCRIPTION
目前该库虽然功能比较完善，但是性能较差，无论任何操作均会导致所有的组件重新渲染(甚至重新创建)

该Request将Days组件拆分出一个Day组件，也就是日历的单元格，并对Day组件影响性能的属性进行了梳理，并修改了部分性能文档说明

由于属性较多，目前优化到了Day组件，测试切换选中日历，Day组件，前面会重新渲染120多次(3个月所有的单元格)，目前会重渲染4次。
